### PR TITLE
fix: return value of the advice on `message`

### DIFF
--- a/mini-modeline.el
+++ b/mini-modeline.el
@@ -278,7 +278,8 @@ Return value is (STRING . LINES)."
       (apply func args)
     (let* ((inhibit-message t)
            (mini-modeline--msg-message (apply func args)))
-      (mini-modeline-display 'force))))
+      (mini-modeline-display 'force)
+      mini-modeline--msg-message)))
 
 (defmacro mini-modeline--wrap (func &rest body)
   "Add an advice around FUNC with name mini-modeline--%s.


### PR DESCRIPTION
Fix #44.