### PR TITLE
Fixed behavior when mini-modeline-truncate-p is nil

### DIFF
--- a/mini-modeline.el
+++ b/mini-modeline.el
@@ -255,7 +255,7 @@ When ARG is:
           (cons
            (let ((available-width (+ available-width (string-width left))))
              (format (format "%%0.%ds\n%%s" available-width) right left))
-           1))
+           (ceiling (string-width left) (frame-width mini-modeline-frame))))
       (cons (format (format "%%s %%%ds" available-width) left right) 0))))
 
 (defun mini-modeline--multi-lr-render (left right)


### PR DESCRIPTION
Previously, messages longer than one line were truncated anyway, when mini-modeline-truncate-p was nil. Now, the minibuffer is resized as needed.