### PR TITLE
Make overduep a defsubst instead of defmacro

### DIFF
--- a/mini-modeline.el
+++ b/mini-modeline.el
@@ -158,9 +158,9 @@ Set this to the minimal value that doesn't cause truncation."
         (goto-char (point-max))
         (insert (apply #'format args))))))
 
-(defmacro mini-modeline--overduep (since duration)
+(defsubst mini-modeline--overduep (since duration)
   "Check if time already pass DURATION from SINCE."
-  `(>= (float-time (time-since ,since)) ,duration))
+  (>= (float-time (time-since since)) duration))
 
 (defvar mini-modeline--minibuffer nil)
 (defun mini-modeline-display (&optional arg)


### PR DESCRIPTION
There is no reason for this to be a macro, but it could well be a
defsubst for increased compiled efficiency.