### PR TITLE
Use idle-timer for increased performance

### DIFF
--- a/mini-modeline.el
+++ b/mini-modeline.el
@@ -366,7 +366,7 @@ BODY will be supplied with orig-func and args."
   (setq resize-mini-windows nil)
   (redisplay)
   ;; (add-hook 'pre-redisplay-functions #'mini-modeline-display)
-  (setq mini-modeline--timer (run-with-timer 0 0.1 #'mini-modeline-display))
+  (setq mini-modeline--timer (run-with-idle-timer 0.1 t #'mini-modeline-display))
   (advice-add #'message :around #'mini-modeline--reroute-msg)
 
   (add-hook 'minibuffer-setup-hook #'mini-modeline--enter-minibuffer)


### PR DESCRIPTION
I’ve been using this for some weeks now, and find it perfectly tolerable. The modeline is sometimes not updated directly instantly, but in most cases it is. 

Fixes #53

But maybe `mini-modeline-display` could be added to some suitable hooks (maybe focus events, I have a recollection of it not working perfectly when emacs is out of focus for some reason).
