### PR TITLE
Add user option `mini-modeline-hide-mode-line'

### DIFF
--- a/mini-modeline.el
+++ b/mini-modeline.el
@@ -81,6 +81,11 @@
   :type 'boolean
   :group 'mini-modeline)
 
+(defcustom mini-modeline-hide-mode-line t
+  "Turn off the main modeline when `mini-modeline-mode' is active."
+  :type 'boolean
+  :group 'mini-modeline)
+
 (defface mini-modeline-mode-line
   '((((background light))
      :background "#55ced1" :height 0.14 :box nil)
@@ -326,43 +331,44 @@ BODY will be supplied with orig-func and args."
 
 (defun mini-modeline--enable ()
   "Enable `mini-modeline'."
-  ;; Hide modeline for terminal, or use empty modeline for GUI.
-  (setq-default mini-modeline--orig-mode-line mode-line-format)
-  (setq-default mode-line-format (when (and mini-modeline-display-gui-line
-                                            (display-graphic-p))
-                                   '(" ")))
-  ;; Do the same thing with opening buffers.
-  (mapc
-   (lambda (buf)
-     (with-current-buffer buf
-       (when (local-variable-p 'mode-line-format)
-         (setq mini-modeline--orig-mode-line mode-line-format)
-         (setq mode-line-format (when (and mini-modeline-display-gui-line
-                                           (display-graphic-p))
-                                  '(" "))))
-       (when (and mini-modeline-enhance-visual
-                  (or (minibufferp buf)
-                      (string-prefix-p " *Echo Area" (buffer-name))))
-         (mini-modeline--set-buffer-face))
-       ;; Make the modeline in GUI a thin bar.
-       (when (and mini-modeline-display-gui-line
-                  (local-variable-p 'face-remapping-alist)
-                  (display-graphic-p))
-         (setf (alist-get 'mode-line face-remapping-alist)
-               'mini-modeline-mode-line
-               (alist-get 'mode-line-inactive face-remapping-alist)
-               'mini-modeline-mode-line-inactive))))
-   (buffer-list))
+  (when mini-modeline-hide-mode-line
+    ;; Hide modeline for terminal, or use empty modeline for GUI.
+    (setq-default mini-modeline--orig-mode-line mode-line-format)
+    (setq-default mode-line-format (when (and mini-modeline-display-gui-line
+                                              (display-graphic-p))
+                                     '(" ")))
+    ;; Do the same thing with opening buffers.
+    (mapc
+     (lambda (buf)
+       (with-current-buffer buf
+         (when (local-variable-p 'mode-line-format)
+           (setq mini-modeline--orig-mode-line mode-line-format)
+           (setq mode-line-format (when (and mini-modeline-display-gui-line
+                                             (display-graphic-p))
+                                    '(" "))))
+         (when (and mini-modeline-enhance-visual
+                    (or (minibufferp buf)
+                        (string-prefix-p " *Echo Area" (buffer-name))))
+           (mini-modeline--set-buffer-face))
+         ;; Make the modeline in GUI a thin bar.
+         (when (and mini-modeline-display-gui-line
+                    (local-variable-p 'face-remapping-alist)
+                    (display-graphic-p))
+           (setf (alist-get 'mode-line face-remapping-alist)
+                 'mini-modeline-mode-line
+                 (alist-get 'mode-line-inactive face-remapping-alist)
+                 'mini-modeline-mode-line-inactive))))
+     (buffer-list))
 
-  ;; Make the modeline in GUI a thin bar.
-  (when (and mini-modeline-display-gui-line
-             (display-graphic-p))
-    (let ((face-remaps (default-value 'face-remapping-alist)))
-      (setf (alist-get 'mode-line face-remaps)
-            'mini-modeline-mode-line
-            (alist-get 'mode-line-inactive face-remaps)
-            'mini-modeline-mode-line-inactive
-            (default-value 'face-remapping-alist) face-remaps)))
+    ;; Make the modeline in GUI a thin bar.
+    (when (and mini-modeline-display-gui-line
+               (display-graphic-p))
+      (let ((face-remaps (default-value 'face-remapping-alist)))
+        (setf (alist-get 'mode-line face-remaps)
+              'mini-modeline-mode-line
+              (alist-get 'mode-line-inactive face-remaps)
+              'mini-modeline-mode-line-inactive
+              (default-value 'face-remapping-alist) face-remaps))))
 
   (setq mini-modeline--orig-resize-mini-windows resize-mini-windows)
   (setq resize-mini-windows nil)
@@ -403,29 +409,30 @@ BODY will be supplied with orig-func and args."
 
 (defun mini-modeline--disable ()
   "Disable `mini-modeline'."
-  (setq-default mode-line-format (default-value 'mini-modeline--orig-mode-line))
-  (when (display-graphic-p)
-    (let ((face-remaps (default-value 'face-remapping-alist)))
-      (setf (alist-get 'mode-line face-remaps)
-            mini-modeline--orig-mode-line-remap
-            (alist-get 'mode-line-inactive face-remaps)
-            mini-modeline--orig-mode-line-inactive-remap
-            (default-value 'face-remapping-alist) face-remaps)))
+  (when mini-modeline-hide-mode-line
+    (setq-default mode-line-format (default-value 'mini-modeline--orig-mode-line))
+    (when (display-graphic-p)
+      (let ((face-remaps (default-value 'face-remapping-alist)))
+        (setf (alist-get 'mode-line face-remaps)
+              mini-modeline--orig-mode-line-remap
+              (alist-get 'mode-line-inactive face-remaps)
+              mini-modeline--orig-mode-line-inactive-remap
+              (default-value 'face-remapping-alist) face-remaps)))
 
-  (mapc
-   (lambda (buf)
-     (with-current-buffer buf
-       (when (local-variable-p 'mode-line-format)
-         (setq mode-line-format mini-modeline--orig-mode-line))
-       (when mini-modeline--face-cookie
-         (face-remap-remove-relative mini-modeline--face-cookie))
-       (when (and (local-variable-p 'face-remapping-alist)
-                  (display-graphic-p))
-         (setf (alist-get 'mode-line face-remapping-alist)
-               mini-modeline--orig-mode-line-remap
-               (alist-get 'mode-line-inactive face-remapping-alist)
-               mini-modeline--orig-mode-line-inactive-remap))))
-   (buffer-list))
+    (mapc
+     (lambda (buf)
+       (with-current-buffer buf
+         (when (local-variable-p 'mode-line-format)
+           (setq mode-line-format mini-modeline--orig-mode-line))
+         (when mini-modeline--face-cookie
+           (face-remap-remove-relative mini-modeline--face-cookie))
+         (when (and (local-variable-p 'face-remapping-alist)
+                    (display-graphic-p))
+           (setf (alist-get 'mode-line face-remapping-alist)
+                 mini-modeline--orig-mode-line-remap
+                 (alist-get 'mode-line-inactive face-remapping-alist)
+                 mini-modeline--orig-mode-line-inactive-remap))))
+     (buffer-list)))
 
   (setq resize-mini-windows mini-modeline--orig-resize-mini-windows)
   (redisplay)


### PR DESCRIPTION
When non-nil (the default), hide the main mode-line.  If nil, don't.

Useful for when a user (me, for example) just wants global information like `display-time-mode` or the like to display once.